### PR TITLE
Fix lib/printf.c NULL pointer

### DIFF
--- a/lib/printf.c
+++ b/lib/printf.c
@@ -87,7 +87,7 @@ static void * outfunc( void * op, const char * buf, size_t n )
 **/
 int vprintf ( const char *fmt, va_list ap )
 {
-    return format( outfunc, NULL, fmt, ap );
+    return format( outfunc, (void*)!NULL, fmt, ap );
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Passing NULL as the second parameter to format() results in incorrect output.
