### PR TITLE
Fix unnecessary comparison, -Wtype-limits warning

### DIFF
--- a/src/format.c
+++ b/src/format.c
@@ -1306,7 +1306,6 @@ int format( void *    (* cons) (void *, const char * , size_t),
                 if ( READ_CHAR( mode, ptr ) == '*' )
                 {
                     p = va_arg( ap, int );
-                    p = MAX( 0, p );
 
                     INC_VOID_PTR( ptr );
                 }
@@ -1329,7 +1328,6 @@ int format( void *    (* cons) (void *, const char * , size_t),
                 else if ( READ_CHAR( mode, INC_VOID_PTR(ptr) ) == '*' )
                 {
                     q = va_arg( ap, int );
-                    q = MAX( 0, q );
 
                     INC_VOID_PTR( ptr );
                 }


### PR DESCRIPTION
warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]

p and q are size_t, it's likely safe to assume all modern compilers define size_t as unsigned so these checks are not necessary.

https://www.gnu.org/software/libc/manual/html_node/Important-Data-Types.html

Alternatives would be changing size_t to a signed type and leaving the checks, or to an unsigned type and removing the checks.
